### PR TITLE
feat(admin): complete jurisdiction rollout follow-up

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,11 @@
 # RAG document search (GroundX) and answer generation (Gemini). Local Next.js
-# routes and Convex actions both use these server-only values. In hosted
-# environments, set them in both Vercel and Convex; never commit real values.
+# routes and applicable Convex actions use these server-only API keys. In hosted
+# environments, set each API key wherever its provider action runs; never commit real values.
 GROUNDX_API_KEY=
 GOOGLE_AI_API_KEY=
+# Optional Next.js chat model override. It defaults to gemini-3.5-flash-lite
+# when unset or empty; do not expose it with a NEXT_PUBLIC_ prefix.
+GOOGLE_AI_MODEL=
 
 # Google Places is used only by the server-side geographic jurisdiction
 # verification routes. Configure it on the Next.js host (Vercel in deployed

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/.pnpm-store/
 /.pnp
 .pnp.js
 .yarn/install-state.gz

--- a/convex/admin/permissions.test.ts
+++ b/convex/admin/permissions.test.ts
@@ -37,6 +37,9 @@ type AuthFixture = {
 const setAdminPanel = makeFunctionReference<"mutation">(
   "admin/featureFlags:setAdminPanel",
 );
+const recordAdminStepUpProof = makeFunctionReference<"mutation">(
+  "admin/users:recordAdminStepUpProof",
+);
 const setUnifiedJurisdictions = makeFunctionReference<"mutation">(
   "admin/featureFlags:setUnifiedJurisdictions",
 );
@@ -228,6 +231,39 @@ describe("admin permission registry", () => {
       operations: await ctx.db.query("adminOperations").withIndex("by_actorId_and_idempotencyKey", (q) => q.eq("actorId", actor.userId).eq("idempotencyKey", "flag-enable-1")).take(2),
       audits: (await ctx.db.query("auditEvents").withIndex("by_actorId_and_createdAt", (q) => q.eq("actorId", actor.userId)).take(10)).filter((row) => row.action === "admin.panel_flag_set" && row.correlationId === replay.correlationId),
     }))).resolves.toMatchObject({ operations: [expect.any(Object)], audits: [expect.any(Object)] });
+  });
+
+  it("records a unified-jurisdictions step-up proof only for the current environment", async () => {
+    const t = createTestBackend();
+    const actor = await createAuthFixture(t, {
+      role: "super_admin",
+      twoFactorEnabled: true,
+    });
+
+    await expect(t.mutation(recordAdminStepUpProof, {
+      actorId: actor.userId,
+      sessionId: actor.sessionId,
+      action: "unified_jurisdictions_set",
+      targetId: "unified_jurisdictions:test",
+      idempotencyKey: "unified-proof-current-environment",
+    })).resolves.toBeNull();
+    await expect(t.mutation(recordAdminStepUpProof, {
+      actorId: actor.userId,
+      sessionId: actor.sessionId,
+      action: "unified_jurisdictions_set",
+      targetId: "unified_jurisdictions:production",
+      idempotencyKey: "unified-proof-wrong-environment",
+    })).rejects.toThrow("ADMIN_STEP_UP_SCOPE_INVALID");
+
+    await expect(t.run((ctx) =>
+      ctx.db.query("adminStepUpProofs").take(2),
+    )).resolves.toMatchObject([{
+      actorId: actor.userId,
+      sessionId: actor.sessionId,
+      action: "unified_jurisdictions_set",
+      targetId: "unified_jurisdictions:test",
+      idempotencyKey: "unified-proof-current-environment",
+    }]);
   });
 
   it("enables unified jurisdictions only after Ghana and every second clean execute pass are ready", async () => {

--- a/convex/admin/users.ts
+++ b/convex/admin/users.ts
@@ -1241,6 +1241,15 @@ export const recordAdminStepUpProof = internalMutation({
       ) {
         throw new ConvexError("ADMIN_STEP_UP_SCOPE_INVALID");
       }
+    } else if (args.action === "unified_jurisdictions_set") {
+      if (
+        typeof session.impersonatedBy === "string" ||
+        !hasRolePermission(parseAdminRoles(actor.role), "user", "set_role") ||
+        args.targetId !==
+          `unified_jurisdictions:${process.env.ADMIN_ENVIRONMENT}`
+      ) {
+        throw new ConvexError("ADMIN_STEP_UP_SCOPE_INVALID");
+      }
     } else if (args.action.startsWith("document_")) {
       const permission = args.action === "document_rollback" ? "rollback" : "publish";
       const version = await ctx.db.get(args.targetId as Id<"documentVersions">);

--- a/docs/admin/bootstrap.md
+++ b/docs/admin/bootstrap.md
@@ -10,6 +10,7 @@
 | --- | --- | --- | --- | --- |
 | `GROUNDX_API_KEY` | Vercel and Convex | Required for provider work | Required | Required |
 | `GOOGLE_AI_API_KEY` | Vercel and Convex | Required for generated answers | Required | Required |
+| `GOOGLE_AI_MODEL` | Vercel | Optional; defaults to `gemini-3.5-flash-lite` | Optional; defaults to `gemini-3.5-flash-lite` | Optional; defaults to `gemini-3.5-flash-lite` |
 | `PLACES_API_KEY` | Vercel | Required when geographic jurisdiction verification is used | Required when geographic jurisdiction verification is used | Required when geographic jurisdiction verification is used |
 | `PLACE_CLAIM_SECRET` | Vercel and Convex | Required when geographic jurisdiction verification is used | Required when geographic jurisdiction verification is used | Required when geographic jurisdiction verification is used |
 | `CONVEX_DEPLOYMENT` | local shell / Vercel build | Required | Required | Required |
@@ -105,7 +106,7 @@ Do not reuse a preview user ID or run the isolated `convex dev` sequence against
 ### 1. Deploy disabled and prepare the production account
 
 1. In the Convex production deployment, set `ADMIN_ENVIRONMENT=production` and `ADMIN_PANEL_ENABLED=false`. Confirm `INITIAL_SUPER_ADMIN_IDS` is absent. Configure the Convex-owned variables in the matrix.
-2. In the Vercel **Production** environment, configure the Vercel-owned variables in the matrix. `GROUNDX_API_KEY`, `GOOGLE_AI_API_KEY`, `PLACES_API_KEY`, `PLACE_CLAIM_SECRET`, `SEARCH_JURISDICTION_SECRET`, and `TELEMETRY_INGEST_SECRET` are server-only even though Vercel also needs them; never prefix them with `NEXT_PUBLIC_`. Geographic jurisdiction verification requires Vercel's `PLACES_API_KEY` and the identical 32+ character `PLACE_CLAIM_SECRET` in Vercel and Convex. The shared search and telemetry secrets must each match Convex exactly.
+2. In the Vercel **Production** environment, configure the Vercel-owned variables in the matrix. `GROUNDX_API_KEY`, `GOOGLE_AI_API_KEY`, `GOOGLE_AI_MODEL`, `PLACES_API_KEY`, `PLACE_CLAIM_SECRET`, `SEARCH_JURISDICTION_SECRET`, and `TELEMETRY_INGEST_SECRET` are server-only even though Vercel also needs them; never prefix them with `NEXT_PUBLIC_`. Geographic jurisdiction verification requires Vercel's `PLACES_API_KEY` and the identical 32+ character `PLACE_CLAIM_SECRET` in Vercel and Convex. The shared search and telemetry secrets must each match Convex exactly.
 3. Promote the already-reviewed commit through the normal `main` deployment pipeline. Do not run an ad hoc `convex deploy` from the release shell: that command defaults to the project's production deployment and does not accept the exact-name selector used below.
 4. Verify the production site loads while ordinary `/admin` access remains disabled. The candidate must create a new production credential account, verify its email, enroll in 2FA at `/settings/security`, and copy the production Better Auth user ID. Verify the production ID, email-verification state, and 2FA state in that same environment.
 

--- a/src/app/admin-recovery/page.test.tsx
+++ b/src/app/admin-recovery/page.test.tsx
@@ -1,8 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   authorizeAdminRecoveryPage: vi.fn(),
+  fetchAuthQuery: vi.fn(),
   redirect: vi.fn(),
+  unifiedControl: vi.fn(),
 }));
 
 vi.mock("@/lib/admin/server", () => ({
@@ -11,26 +14,63 @@ vi.mock("@/lib/admin/server", () => ({
 vi.mock("@/components/admin/admin-recovery-control", () => ({
   AdminRecoveryControl: () => null,
 }));
+vi.mock("@/components/admin/unified-jurisdictions-recovery-control", () => ({
+  UnifiedJurisdictionsRecoveryControl: (props: unknown) => {
+    mocks.unifiedControl(props);
+    return null;
+  },
+}));
+vi.mock("@/lib/auth-server", () => ({
+  fetchAuthQuery: mocks.fetchAuthQuery,
+}));
 vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
 
+import { api } from "../../../convex/_generated/api";
 import AdminRecoveryPage from "./page";
+
+const rollout = {
+  environment: "preview",
+  migrationVersion: "jurisdiction_ids_v1",
+  flagEnabled: false,
+  ghana: { ready: true, jurisdictionId: null, reasons: [] },
+  targets: [],
+  blockers: [],
+  canEnable: true,
+  legacyObservation: {
+    active: false,
+    generation: 0,
+    startedAt: null,
+    lastAcceptedAt: null,
+    acceptedSinceStart: 0,
+    zeroForMs: null,
+  },
+} as const;
+
+afterEach(cleanup);
 
 describe("admin recovery page access", () => {
   beforeEach(() => {
     mocks.authorizeAdminRecoveryPage.mockReset();
+    mocks.fetchAuthQuery.mockReset().mockResolvedValue(rollout);
     mocks.redirect.mockReset().mockImplementation(() => {
       throw new Error("NEXT_REDIRECT");
     });
+    mocks.unifiedControl.mockReset();
   });
 
-  it("renders for an assured non-impersonated Super Admin while the persisted flag is off", async () => {
+  it("loads unified rollout readiness for an assured non-impersonated Super Admin", async () => {
     mocks.authorizeAdminRecoveryPage.mockResolvedValue({
       status: "authorized",
       state: { environment: "preview", enabled: false },
     });
 
-    await expect(AdminRecoveryPage()).resolves.toBeTruthy();
+    render(await AdminRecoveryPage());
     expect(mocks.redirect).not.toHaveBeenCalled();
+    expect(mocks.fetchAuthQuery).toHaveBeenCalledWith(
+      api.admin.featureFlags.getUnifiedJurisdictionRolloutState,
+      {},
+    );
+    expect(mocks.unifiedControl).toHaveBeenCalledWith({ rollout });
   });
 
   it("redirects denied sessions outside the disabled /admin layout", async () => {
@@ -38,5 +78,6 @@ describe("admin recovery page access", () => {
 
     await expect(AdminRecoveryPage()).rejects.toThrow("NEXT_REDIRECT");
     expect(mocks.redirect).toHaveBeenCalledWith("/admin/forbidden");
+    expect(mocks.fetchAuthQuery).not.toHaveBeenCalled();
   });
 });

--- a/src/app/admin-recovery/page.test.tsx
+++ b/src/app/admin-recovery/page.test.tsx
@@ -1,9 +1,10 @@
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   authorizeAdminRecoveryPage: vi.fn(),
   fetchAuthQuery: vi.fn(),
+  adminControl: vi.fn(),
   redirect: vi.fn(),
   unifiedControl: vi.fn(),
 }));
@@ -12,7 +13,10 @@ vi.mock("@/lib/admin/server", () => ({
   authorizeAdminRecoveryPage: mocks.authorizeAdminRecoveryPage,
 }));
 vi.mock("@/components/admin/admin-recovery-control", () => ({
-  AdminRecoveryControl: () => null,
+  AdminRecoveryControl: (props: unknown) => {
+    mocks.adminControl(props);
+    return <div>Admin panel recovery available</div>;
+  },
 }));
 vi.mock("@/components/admin/unified-jurisdictions-recovery-control", () => ({
   UnifiedJurisdictionsRecoveryControl: (props: unknown) => {
@@ -52,6 +56,7 @@ describe("admin recovery page access", () => {
   beforeEach(() => {
     mocks.authorizeAdminRecoveryPage.mockReset();
     mocks.fetchAuthQuery.mockReset().mockResolvedValue(rollout);
+    mocks.adminControl.mockReset();
     mocks.redirect.mockReset().mockImplementation(() => {
       throw new Error("NEXT_REDIRECT");
     });
@@ -79,5 +84,23 @@ describe("admin recovery page access", () => {
     await expect(AdminRecoveryPage()).rejects.toThrow("NEXT_REDIRECT");
     expect(mocks.redirect).toHaveBeenCalledWith("/admin/forbidden");
     expect(mocks.fetchAuthQuery).not.toHaveBeenCalled();
+  });
+
+  it("keeps admin-panel recovery available when rollout readiness cannot load", async () => {
+    mocks.authorizeAdminRecoveryPage.mockResolvedValue({
+      status: "authorized",
+      state: { environment: "preview", enabled: false },
+    });
+    mocks.fetchAuthQuery.mockRejectedValue(new Error("rollout unavailable"));
+
+    render(await AdminRecoveryPage());
+
+    expect(mocks.adminControl).toHaveBeenCalledWith({
+      environment: "preview",
+      enabled: false,
+    });
+    expect(screen.getByText("Admin panel recovery available")).toBeInTheDocument();
+    expect(screen.getByText("Unified jurisdictions unavailable")).toBeInTheDocument();
+    expect(mocks.unifiedControl).not.toHaveBeenCalled();
   });
 });

--- a/src/app/admin-recovery/page.tsx
+++ b/src/app/admin-recovery/page.tsx
@@ -12,7 +12,7 @@ export default async function AdminRecoveryPage() {
   const rollout = await fetchAuthQuery(
     api.admin.featureFlags.getUnifiedJurisdictionRolloutState,
     {},
-  );
+  ).catch(() => null);
 
   return (
     <main className="min-h-screen bg-[oklch(96%_0.016_82)] text-[oklch(24%_0.035_252)]">
@@ -27,7 +27,16 @@ export default async function AdminRecoveryPage() {
           Available only to an assured, non-impersonated Super Admin. Every change requires a fresh password proof, an exact confirmation, a reason, and an idempotency key.
         </p>
         <AdminRecoveryControl {...access.state} />
-        <UnifiedJurisdictionsRecoveryControl rollout={rollout} />
+        {rollout ? (
+          <UnifiedJurisdictionsRecoveryControl rollout={rollout} />
+        ) : (
+          <section className="mt-6 border border-amber-700/30 bg-white/70 p-5">
+            <h2 className="text-lg font-semibold">Unified jurisdictions unavailable</h2>
+            <p className="mt-2 text-sm leading-6 text-[oklch(39%_0.035_252)]">
+              Rollout readiness could not be loaded. Admin-panel recovery remains available above; retry unified-jurisdiction recovery after the rollout service is healthy.
+            </p>
+          </section>
+        )}
         <p className="mt-8 text-sm leading-6">
           <Link href="/" className="font-semibold underline decoration-2 underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-700">
             Return to the public site

--- a/src/app/admin-recovery/page.tsx
+++ b/src/app/admin-recovery/page.tsx
@@ -1,11 +1,18 @@
 import { AdminRecoveryControl } from "@/components/admin/admin-recovery-control";
+import { UnifiedJurisdictionsRecoveryControl } from "@/components/admin/unified-jurisdictions-recovery-control";
+import { fetchAuthQuery } from "@/lib/auth-server";
 import { authorizeAdminRecoveryPage } from "@/lib/admin/server";
+import { api } from "../../../convex/_generated/api";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
 export default async function AdminRecoveryPage() {
   const access = await authorizeAdminRecoveryPage();
   if (access.status === "denied") redirect("/admin/forbidden");
+  const rollout = await fetchAuthQuery(
+    api.admin.featureFlags.getUnifiedJurisdictionRolloutState,
+    {},
+  );
 
   return (
     <main className="min-h-screen bg-[oklch(96%_0.016_82)] text-[oklch(24%_0.035_252)]">
@@ -20,6 +27,7 @@ export default async function AdminRecoveryPage() {
           Available only to an assured, non-impersonated Super Admin. Every change requires a fresh password proof, an exact confirmation, a reason, and an idempotency key.
         </p>
         <AdminRecoveryControl {...access.state} />
+        <UnifiedJurisdictionsRecoveryControl rollout={rollout} />
         <p className="mt-8 text-sm leading-6">
           <Link href="/" className="font-semibold underline decoration-2 underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-700">
             Return to the public site

--- a/src/components/admin/step-up-dialog.test.tsx
+++ b/src/components/admin/step-up-dialog.test.tsx
@@ -1,0 +1,52 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { StepUpDialog } from "./step-up-dialog";
+
+afterEach(cleanup);
+
+describe("step-up dialog accessibility", () => {
+  it("associates each dialog with its own title and description", () => {
+    const onConfirmed = vi.fn(async () => {});
+    const { container } = render(
+      <>
+        <StepUpDialog
+          open={false}
+          title="Admin recovery"
+          description="Admin recovery description"
+          submitLabel="Apply admin recovery"
+          targetId="admin_panel:preview"
+          idempotencyKey="admin-recovery-key"
+          onClose={() => {}}
+          onConfirmed={onConfirmed}
+        />
+        <StepUpDialog
+          open={false}
+          title="Unified jurisdictions"
+          description="Unified jurisdictions description"
+          submitLabel="Apply unified jurisdictions"
+          targetId="unified_jurisdictions:preview"
+          idempotencyKey="unified-jurisdictions-key"
+          onClose={() => {}}
+          onConfirmed={onConfirmed}
+        />
+      </>,
+    );
+
+    const dialogs = Array.from(container.querySelectorAll("dialog"));
+    const titleIds = dialogs.map((dialog) => dialog.getAttribute("aria-labelledby"));
+    const descriptionIds = dialogs.map((dialog) =>
+      dialog.getAttribute("aria-describedby"),
+    );
+
+    expect(new Set(titleIds).size).toBe(2);
+    expect(new Set(descriptionIds).size).toBe(2);
+    expect(document.getElementById(titleIds[0]!)).toHaveTextContent("Admin recovery");
+    expect(document.getElementById(titleIds[1]!)).toHaveTextContent("Unified jurisdictions");
+    expect(document.getElementById(descriptionIds[0]!)).toHaveTextContent(
+      "Admin recovery description",
+    );
+    expect(document.getElementById(descriptionIds[1]!)).toHaveTextContent(
+      "Unified jurisdictions description",
+    );
+  });
+});

--- a/src/components/admin/step-up-dialog.tsx
+++ b/src/components/admin/step-up-dialog.tsx
@@ -2,6 +2,7 @@
 
 import {
   useEffect,
+  useId,
   useRef,
   useState,
   type FormEvent,
@@ -39,6 +40,8 @@ export function StepUpDialog({
 }: StepUpDialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const formRef = useRef<HTMLFormElement>(null);
+  const titleId = useId();
+  const descriptionId = useId();
   const [status, setStatus] = useState<"idle" | "working" | "error">("idle");
   const [error, setError] = useState("");
 
@@ -111,8 +114,8 @@ export function StepUpDialog({
   return (
     <dialog
       ref={dialogRef}
-      aria-labelledby="admin-step-up-title"
-      aria-describedby="admin-step-up-description"
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
       onCancel={(event) => {
         event.preventDefault();
         if (status !== "working") onClose();
@@ -125,13 +128,13 @@ export function StepUpDialog({
             Account authority
           </p>
           <h2
-            id="admin-step-up-title"
+            id={titleId}
             className="mt-2 text-2xl font-semibold tracking-[-0.035em]"
           >
             {title}
           </h2>
           <p
-            id="admin-step-up-description"
+            id={descriptionId}
             className="mt-3 max-w-[58ch] text-sm leading-6 text-[oklch(39%_0.035_252)]"
           >
             {description}

--- a/src/components/admin/unified-jurisdictions-recovery-control.test.tsx
+++ b/src/components/admin/unified-jurisdictions-recovery-control.test.tsx
@@ -1,0 +1,130 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { UnifiedJurisdictionRolloutState } from "../../../convex/lib/unifiedJurisdictionRollout";
+
+const mutation = vi.fn();
+vi.mock("convex/react", () => ({ useMutation: () => mutation }));
+
+import { UnifiedJurisdictionsRecoveryControl } from "./unified-jurisdictions-recovery-control";
+
+const readyRollout: UnifiedJurisdictionRolloutState = {
+  environment: "preview",
+  migrationVersion: "jurisdiction_ids_v1",
+  flagEnabled: false,
+  ghana: { ready: true, jurisdictionId: null, reasons: [] },
+  targets: [
+    { target: "chatSessions", status: "verified", processed: 1, updated: 0, unresolved: 0, mismatches: 0, runNumber: 2, verifiedAt: 1 },
+    { target: "telemetryCorrelations", status: "verified", processed: 0, updated: 0, unresolved: 0, mismatches: 0, runNumber: 2, verifiedAt: 1 },
+    { target: "queryRuns", status: "verified", processed: 1, updated: 0, unresolved: 0, mismatches: 0, runNumber: 2, verifiedAt: 1 },
+    { target: "dailyMetrics", status: "verified", processed: 1, updated: 0, unresolved: 0, mismatches: 0, runNumber: 2, verifiedAt: 1 },
+  ],
+  blockers: [],
+  canEnable: true,
+  legacyObservation: {
+    active: false,
+    generation: 0,
+    startedAt: null,
+    lastAcceptedAt: null,
+    acceptedSinceStart: 0,
+    zeroForMs: null,
+  },
+};
+
+afterEach(cleanup);
+
+describe("unified-jurisdictions recovery control", () => {
+  beforeEach(() => {
+    mutation.mockReset().mockResolvedValue({
+      environment: "preview",
+      enabled: true,
+      correlationId: "op_unified_recovery",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 200 })),
+    );
+    vi.spyOn(crypto, "randomUUID").mockReturnValue(
+      "00000000-0000-4000-8000-000000000021",
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("binds the unified flag mutation to a fresh scoped password proof", async () => {
+    render(<UnifiedJurisdictionsRecoveryControl rollout={readyRollout} />);
+
+    expect(screen.getByText("Ready to enable")).toBeVisible();
+    fireEvent.click(screen.getByRole("button", {
+      name: "Enable unified jurisdictions",
+    }));
+    fireEvent.change(screen.getByLabelText("Reason for this action"), {
+      target: { value: "Enable the verified preview jurisdiction rollout" },
+    });
+    fireEvent.change(screen.getByLabelText("Exact confirmation"), {
+      target: { value: "UNIFIED_JURISDICTIONS preview ENABLE" },
+    });
+    fireEvent.change(screen.getByLabelText("Confirm your password"), {
+      target: { value: "private-password" },
+    });
+    fireEvent.click(screen.getByRole("button", {
+      name: "Verify and enable",
+    }));
+
+    await waitFor(() => expect(mutation).toHaveBeenCalledTimes(1));
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/auth/verify-password",
+      expect.objectContaining({
+        credentials: "same-origin",
+        headers: expect.objectContaining({
+          "x-admin-step-up-action": "unified_jurisdictions_set",
+          "x-admin-step-up-target": "unified_jurisdictions:preview",
+          "x-admin-step-up-key": "00000000-0000-4000-8000-000000000021",
+        }),
+        body: JSON.stringify({ password: "private-password" }),
+      }),
+    );
+    expect(mutation).toHaveBeenCalledWith({
+      environment: "preview",
+      enabled: true,
+      confirmation: "UNIFIED_JURISDICTIONS preview ENABLE",
+      reason: "Enable the verified preview jurisdiction rollout",
+      idempotencyKey: "00000000-0000-4000-8000-000000000021",
+    });
+    expect(JSON.stringify(mutation.mock.calls)).not.toContain("private-password");
+    expect(await screen.findByText(/Correlation op_unified_recovery/)).toBeVisible();
+  });
+
+  it("blocks enablement while readiness is red but preserves rollback", () => {
+    const blockedRollout = {
+      ...readyRollout,
+      canEnable: false,
+      blockers: ["CHAT_SESSIONS_NOT_VERIFIED"],
+      targets: readyRollout.targets.map((target) =>
+        target.target === "chatSessions"
+          ? { ...target, status: "blocked" as const, verifiedAt: null }
+          : target,
+      ),
+    };
+    const { unmount } = render(
+      <UnifiedJurisdictionsRecoveryControl rollout={blockedRollout} />,
+    );
+
+    expect(screen.getByRole("button", {
+      name: "Enable unified jurisdictions",
+    })).toBeDisabled();
+    expect(screen.getByText("Chat sessions not verified")).toBeVisible();
+
+    unmount();
+    render(
+      <UnifiedJurisdictionsRecoveryControl
+        rollout={{ ...blockedRollout, flagEnabled: true }}
+      />,
+    );
+    expect(screen.getByRole("button", {
+      name: "Disable unified jurisdictions",
+    })).toBeEnabled();
+  });
+});

--- a/src/components/admin/unified-jurisdictions-recovery-control.tsx
+++ b/src/components/admin/unified-jurisdictions-recovery-control.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import type { UnifiedJurisdictionRolloutState } from "../../../convex/lib/unifiedJurisdictionRollout";
+import { api } from "../../../convex/_generated/api";
+import { useMutation } from "convex/react";
+import { useState } from "react";
+import { StepUpDialog } from "./step-up-dialog";
+
+function blockerLabel(blocker: string) {
+  const label = blocker.toLowerCase().replaceAll("_", " ");
+  return label.replace(/^./, (letter) => letter.toUpperCase());
+}
+
+export function UnifiedJurisdictionsRecoveryControl({
+  rollout,
+}: {
+  rollout: UnifiedJurisdictionRolloutState;
+}) {
+  const setUnifiedJurisdictions = useMutation(
+    api.admin.featureFlags.setUnifiedJurisdictions,
+  );
+  const [enabled, setEnabled] = useState(rollout.flagEnabled);
+  const [desired, setDesired] = useState<boolean | null>(null);
+  const [idempotencyKey, setIdempotencyKey] = useState("");
+  const [feedback, setFeedback] = useState("");
+
+  function begin(nextEnabled: boolean) {
+    setFeedback("");
+    setIdempotencyKey(crypto.randomUUID());
+    setDesired(nextEnabled);
+  }
+
+  const confirmation = desired === null
+    ? ""
+    : `UNIFIED_JURISDICTIONS ${rollout.environment} ${desired ? "ENABLE" : "DISABLE"}`;
+  const verifiedTargets = rollout.targets.filter(
+    (target) => target.status === "verified",
+  ).length;
+
+  async function apply(input: { reason: string; confirmation?: string }) {
+    if (desired === null || !idempotencyKey) return;
+    const result = await setUnifiedJurisdictions({
+      environment: rollout.environment,
+      enabled: desired,
+      confirmation: input.confirmation ?? "",
+      reason: input.reason,
+      idempotencyKey,
+    });
+    setEnabled(desired);
+    setFeedback(
+      `Unified jurisdictions ${desired ? "enabled" : "disabled"}. Correlation ${result.correlationId}.`,
+    );
+  }
+
+  return (
+    <section
+      aria-labelledby="unified-jurisdictions-recovery-heading"
+      className="mt-12 border-y border-[oklch(58%_0.04_252)] py-8"
+    >
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,0.72fr)_minmax(18rem,1.28fr)] lg:items-end">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[oklch(45%_0.07_65)]">
+            Research rollout
+          </p>
+          <h2
+            id="unified-jurisdictions-recovery-heading"
+            className="mt-3 text-3xl font-semibold tracking-[-0.04em]"
+          >
+            {enabled
+              ? "Enabled"
+              : rollout.canEnable
+                ? "Ready to enable"
+                : "Blocked"}
+          </h2>
+          <p className="mt-3 max-w-[52ch] text-sm leading-6 text-[oklch(40%_0.035_252)]">
+            Environment <strong>{rollout.environment}</strong>. Ghana is {rollout.ghana.ready ? "ready" : "not ready"}; {verifiedTargets} of {rollout.targets.length} migration targets are verified.
+          </p>
+          {!enabled && rollout.blockers.length > 0 ? (
+            <ul className="mt-3 grid gap-1 text-sm text-[oklch(38%_0.08_28)]">
+              {rollout.blockers.map((blocker) => (
+                <li key={blocker}>{blockerLabel(blocker)}</li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+        <div className="flex flex-col gap-3 lg:items-end">
+          <button
+            type="button"
+            disabled={!enabled && !rollout.canEnable}
+            onClick={() => begin(!enabled)}
+            className="min-h-11 border border-[oklch(31%_0.055_252)] bg-[oklch(28%_0.055_252)] px-5 py-3 text-sm font-semibold text-[oklch(97%_0.012_82)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-700 disabled:cursor-not-allowed disabled:opacity-45"
+          >
+            {enabled
+              ? "Disable unified jurisdictions"
+              : "Enable unified jurisdictions"}
+          </button>
+          {feedback ? (
+            <p role="status" className="max-w-[52ch] text-sm leading-6">
+              {feedback}
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      <StepUpDialog
+        open={desired !== null}
+        title={`${desired ? "Enable" : "Disable"} unified jurisdictions?`}
+        description="This audited recovery action changes only the unified-jurisdictions flag for the selected environment. Enablement is rejected unless every migration readiness gate remains clean."
+        submitLabel={`Verify and ${desired ? "enable" : "disable"}`}
+        cancelLabel="Cancel rollout action"
+        targetId={`unified_jurisdictions:${rollout.environment}`}
+        idempotencyKey={idempotencyKey}
+        stepUpAction="unified_jurisdictions_set"
+        confirmationPhrase={confirmation}
+        onClose={() => setDesired(null)}
+        onConfirmed={apply}
+      />
+    </section>
+  );
+}

--- a/src/lib/jurisdiction-provider-adapters.test.ts
+++ b/src/lib/jurisdiction-provider-adapters.test.ts
@@ -334,7 +334,7 @@ describe("normal jurisdiction provider adapters", () => {
     expect(createGoogleClient).toHaveBeenCalledOnce();
     expect(createGoogleClient).toHaveBeenCalledWith("google-key");
     expect(create).toHaveBeenCalledWith(expect.objectContaining({
-      model: "gemini-3.1-flash-lite-preview",
+      model: "gemini-3.5-flash-lite",
       config: expect.objectContaining({
         responseMimeType: "text/plain",
         tools: [{ googleSearch: {} }],
@@ -344,5 +344,27 @@ describe("normal jurisdiction provider adapters", () => {
     expect(sendMessage).toHaveBeenCalledWith({ message: "normal question" });
     expect(autocomplete).toHaveBeenCalledWith("Acc", SESSION_TOKEN);
     expect(details).toHaveBeenCalledWith("normal-place", SESSION_TOKEN);
+  });
+
+  it("uses the configured chat model for provider requests", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ text: "normal chat answer" });
+    const create = vi.fn().mockReturnValue({ sendMessage });
+    const createGoogleClient = vi.fn().mockResolvedValue({ chats: { create } });
+    const chat = createChatProvider(
+      { GOOGLE_AI_API_KEY: "google-key", GOOGLE_AI_MODEL: "gemini-3.5-flash" },
+      { createGoogleClient },
+    );
+
+    await expect(chat.generate({
+      mode: "legacy",
+      scenarioQuestion: "normal question",
+      query: "normal question",
+      instruction: "normal instruction",
+      history: [],
+    })).resolves.toBe("normal chat answer");
+
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({
+      model: "gemini-3.5-flash",
+    }));
   });
 });

--- a/src/lib/jurisdiction-provider-adapters.ts
+++ b/src/lib/jurisdiction-provider-adapters.ts
@@ -198,7 +198,7 @@ export function createResearchProvider(
   };
 }
 
-const CHAT_MODEL = "gemini-3.1-flash-lite-preview";
+const DEFAULT_CHAT_MODEL = "gemini-3.5-flash-lite";
 const MAX_CHAT_OUTPUT_TOKENS = 8_192;
 const MAX_CHAT_ANSWER_LENGTH = 32_000;
 const MAX_CHAT_CITATIONS = 16;
@@ -214,10 +214,10 @@ function chatHistory(history: ChatHistoryMessage[]) {
   }));
 }
 
-function chatRequest(call: ChatCall): CreateChatParameters {
+function chatRequest(call: ChatCall, model: string): CreateChatParameters {
   if (call.mode === "legacy") {
     return {
-      model: CHAT_MODEL,
+      model,
       config: {
         temperature: 0.2,
         maxOutputTokens: MAX_CHAT_OUTPUT_TOKENS,
@@ -229,7 +229,7 @@ function chatRequest(call: ChatCall): CreateChatParameters {
     };
   }
   return {
-    model: CHAT_MODEL,
+    model,
     config: {
       temperature: 0,
       maxOutputTokens: MAX_CHAT_OUTPUT_TOKENS,
@@ -286,6 +286,7 @@ export function createChatProvider(
   }
 
   let clientPromise: Promise<ChatClient> | undefined;
+  const model = environment.GOOGLE_AI_MODEL?.trim() || DEFAULT_CHAT_MODEL;
   return {
     async generate(call) {
       if (!clientPromise) {
@@ -295,7 +296,7 @@ export function createChatProvider(
         );
       }
       const client = await clientPromise;
-      const chat = client.chats.create(chatRequest(call));
+      const chat = client.chats.create(chatRequest(call, model));
       const message = call.mode === "governed"
         ? JSON.stringify({ governedContext: call.context, untrustedQuestion: call.query })
         : call.query;


### PR DESCRIPTION
## Summary
- add recovery controls and rollout safeguards for unified jurisdictions
- add fresh-password step-up coverage and recovery-route resilience
- make the jurisdiction provider model configurable and document deployment settings
- preserve existing admin-panel break-glass recovery when rollout readiness is unavailable

## Verification
- Convex permissions tests: 33 passed
- affected UI tests: 20 passed
- TypeScript: passed
- ESLint via its Node entrypoint: passed
- production Next.js build via its Node entrypoint: passed

## Local toolchain note
The Windows Bun shim still fails before launching `bun run lint` with a bin-remap error, including after a clean dependency reinstall. The underlying ESLint, TypeScript, Vitest, and Next.js entrypoints all passed; CI remains the release authority.