### PR TITLE
feat(jurisdictions): queue Gemini setup

### DIFF
--- a/convex/admin/jobs.test.ts
+++ b/convex/admin/jobs.test.ts
@@ -352,6 +352,15 @@ describe("durable Gemini jobs", () => {
       displayName: "law-of-the-land-test-ghana",
       embeddingModel: "models/gemini-embedding-2",
     });
+    const provisionAudits = await t.run(async (ctx) => await ctx.db
+      .query("auditEvents")
+      .withIndex("by_targetType_and_targetId", (q) => q
+        .eq("targetType", "jurisdiction")
+        .eq("targetId", jurisdictionId))
+      .collect());
+    expect(provisionAudits.filter((event) =>
+      event.action === "jurisdiction.gemini_store.provision_queued",
+    )).toHaveLength(1);
     const leaseToken = await claimLease(t, first.jobId);
     await t.mutation(applyGeminiProviderResult, {
       jobId: first.jobId,

--- a/convex/admin/jobs.ts
+++ b/convex/admin/jobs.ts
@@ -471,6 +471,38 @@ async function activeGeminiStoreJob(
   return jobs.flat()[0];
 }
 
+export async function queueGeminiStoreProvision(
+  ctx: MutationCtx,
+  jurisdiction: Doc<"jurisdictions">,
+  actor: { id: string; roles: AdminRole[] },
+  idempotencyKey: string,
+) {
+  if (jurisdiction.status === "archived") throw new ConvexError("JURISDICTION_ARCHIVED");
+  if (jurisdiction.geminiFileSearchStoreName !== undefined) {
+    throw new ConvexError("GEMINI_STORE_ALREADY_CONFIGURED");
+  }
+  const active = await activeGeminiStoreJob(ctx, jurisdiction._id, "gemini_create_store");
+  if (active) return { jobId: active._id, duplicate: true };
+
+  const queued = await persistJob(ctx, {
+    type: "gemini_create_store",
+    targetType: "jurisdictionGeminiStore",
+    targetId: jurisdiction._id,
+    payload: {
+      displayName: geminiDisplayName(jurisdiction.slug),
+      embeddingModel: GEMINI_EMBEDDING_MODEL,
+    },
+    idempotencyKey,
+  }, actor);
+  await ctx.db.patch(jurisdiction._id, {
+    geminiEmbeddingModel: GEMINI_EMBEDDING_MODEL,
+    providerSyncState: "pending",
+    updatedBy: actor.id,
+    updatedAt: Date.now(),
+  });
+  return queued;
+}
+
 async function resourceWithActiveVersion(
   ctx: MutationCtx | QueryCtx,
   jurisdictionId: Id<"jurisdictions">,
@@ -495,32 +527,15 @@ export const provisionJurisdictionGeminiStore = mutation({
     const reason = validateAuditReason(args.reason);
     const jurisdiction = await ctx.db.get(args.jurisdictionId);
     if (!jurisdiction) throw new ConvexError("JURISDICTION_NOT_FOUND");
-    if (jurisdiction.status === "archived") throw new ConvexError("JURISDICTION_ARCHIVED");
-    if (jurisdiction.geminiFileSearchStoreName !== undefined) {
-      throw new ConvexError("GEMINI_STORE_ALREADY_CONFIGURED");
-    }
-    const active = await activeGeminiStoreJob(ctx, jurisdiction._id, "gemini_create_store");
-    if (active) {
-      return { jobId: active._id, duplicate: true };
-    }
-    const queued = await persistJob(ctx, {
-      type: "gemini_create_store",
-      targetType: "jurisdictionGeminiStore",
-      targetId: jurisdiction._id,
-      payload: {
-        displayName: geminiDisplayName(jurisdiction.slug),
-        embeddingModel: GEMINI_EMBEDDING_MODEL,
-      },
-      idempotencyKey: args.idempotencyKey,
-    }, { id: actor.userId, roles: actor.roles });
+    const queued = await queueGeminiStoreProvision(
+      ctx,
+      jurisdiction,
+      { id: actor.userId, roles: actor.roles },
+      args.idempotencyKey,
+    );
+    if (queued.duplicate) return queued;
     const job = await ctx.db.get(queued.jobId);
     if (!job) throw new ConvexError("INTEGRATION_JOB_NOT_FOUND");
-    await ctx.db.patch(jurisdiction._id, {
-      geminiEmbeddingModel: GEMINI_EMBEDDING_MODEL,
-      providerSyncState: "pending",
-      updatedBy: actor.userId,
-      updatedAt: Date.now(),
-    });
     await writeAudit(ctx, {
       actorId: actor.userId,
       actorRoles: actor.roles,

--- a/convex/admin/jurisdictions.test.ts
+++ b/convex/admin/jurisdictions.test.ts
@@ -148,11 +148,29 @@ async function createGeo(
     reason: `Create ${input.name}`,
   });
   if (input.configureSearch) {
-    await admin.backend.run((ctx) => ctx.db.patch(jurisdictionId, {
-      geminiFileSearchStoreName: `fileSearchStores/${input.placeId.replace(/[^a-z0-9-]/g, "-")}`,
-      geminiEmbeddingModel: "models/gemini-embedding-2",
-      providerSyncState: "synced",
-    }));
+    await admin.backend.run(async (ctx) => {
+      const jobs = await ctx.db
+        .query("integrationJobs")
+        .withIndex("by_targetType_and_targetId", (q) => q
+          .eq("targetType", "jurisdictionGeminiStore")
+          .eq("targetId", jurisdictionId))
+        .collect();
+      const updatedAt = Date.now();
+      await Promise.all(jobs
+        .filter((job) => job.type === "gemini_create_store")
+        .map((job) => ctx.db.patch(job._id, {
+          status: "succeeded",
+          leaseToken: undefined,
+          leaseExpiresAt: undefined,
+          nextAttemptAt: undefined,
+          updatedAt,
+        })));
+      await ctx.db.patch(jurisdictionId, {
+        geminiFileSearchStoreName: `fileSearchStores/${input.placeId.replace(/[^a-z0-9-]/g, "-")}`,
+        geminiEmbeddingModel: "models/gemini-embedding-2",
+        providerSyncState: "synced",
+      });
+    });
   }
   return jurisdictionId;
 }
@@ -227,6 +245,69 @@ describe("typed jurisdiction administration", () => {
     expect(enabled).toMatchObject({ status: "enabled" });
     expect(enabled).not.toHaveProperty("geminiFileSearchStoreName");
     expect(enabled).not.toHaveProperty("geminiEmbeddingModel");
+  });
+
+  it("automatically queues Gemini store setup for new geographic and organizational jurisdictions", async () => {
+    const t = createBackend();
+    await enablePanel(t);
+    const admin = await asAdmin(t);
+    const geographicJurisdictionId = await createGeo(admin, {
+      name: "Ghana",
+      placeId: "place-ghana-auto-store",
+      level: "country",
+    });
+    const organizationId = await t.run((ctx) => {
+      const now = Date.now();
+      return ctx.db.insert("organizations", {
+        name: "Ghana Law Society",
+        slug: "ghana-law-society",
+        class: "professional_association",
+        status: "active",
+        createdBy: "fixture",
+        updatedBy: "fixture",
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+    const organizationalJurisdictionId = await admin.client.mutation(
+      createOrganizationalJurisdiction,
+      {
+        organizationId,
+        visibility: "members",
+        scopeMode: "global",
+        geographicJurisdictionIds: [],
+        reason: "Create Ghana Law Society jurisdiction",
+      },
+    );
+
+    const created = await t.run(async (ctx) => ({
+      geographic: await ctx.db.get("jurisdictions", geographicJurisdictionId),
+      organizational: await ctx.db.get("jurisdictions", organizationalJurisdictionId),
+      jobs: await ctx.db.query("integrationJobs").take(4),
+    }));
+
+    expect(created.geographic).toMatchObject({
+      providerSyncState: "pending",
+      geminiEmbeddingModel: "models/gemini-embedding-2",
+    });
+    expect(created.organizational).toMatchObject({
+      providerSyncState: "pending",
+      geminiEmbeddingModel: "models/gemini-embedding-2",
+    });
+    expect(created.jobs).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: "gemini_create_store",
+        targetType: "jurisdictionGeminiStore",
+        targetId: geographicJurisdictionId,
+        status: "queued",
+      }),
+      expect.objectContaining({
+        type: "gemini_create_store",
+        targetType: "jurisdictionGeminiStore",
+        targetId: organizationalJurisdictionId,
+        status: "queued",
+      }),
+    ]));
   });
 
   it("requires an enabled broader geographic parent and rejects cycles", async () => {

--- a/convex/admin/jurisdictions.ts
+++ b/convex/admin/jurisdictions.ts
@@ -32,6 +32,7 @@ import {
   requireEnabledAdminCatalogRead,
   requireEnabledAdminPermission,
 } from "./featureFlags";
+import { queueGeminiStoreProvision } from "./jobs";
 
 const MAX_TEXT_LENGTH = 300;
 const MAX_SCOPE_LINKS = 8;
@@ -1078,6 +1079,12 @@ export const createGeographicJurisdiction = mutation({
         place.aliases,
       ),
     });
+    await queueGeminiStoreProvision(
+      ctx,
+      created,
+      { id: actor.userId, roles: actor.roles },
+      `provision-gemini-${id}`,
+    );
     return id;
   },
 });
@@ -1239,6 +1246,12 @@ export const createOrganizationalJurisdiction = mutation({
         profiles,
       ),
     });
+    await queueGeminiStoreProvision(
+      ctx,
+      created,
+      { id: actor.userId, roles: actor.roles },
+      `provision-gemini-${id}`,
+    );
     return id;
   },
 });

--- a/src/components/admin/catalog-actions.test.tsx
+++ b/src/components/admin/catalog-actions.test.tsx
@@ -379,21 +379,13 @@ describe("jurisdiction lifecycle actions", () => {
     );
   });
 
-  it("queues controlled Gemini setup for a draft jurisdiction", async () => {
+  it("does not offer manual Gemini setup for a new draft jurisdiction", () => {
     render(<JurisdictionLifecycleActions jurisdiction={{
       id: "geo_1", name: "Ghana", slug: "ghana", status: "draft", kind: "geographic", visibility: "public", scopeMode: null,
       provider: { syncState: "pending", setupState: "not_set_up", storeConfigured: false }, geographic: { level: "country", parent: null },
     }} />);
 
-    fireEvent.change(screen.getByRole("textbox", { name: "Audit reason for Ghana" }), { target: { value: "Set up legal search" } });
-    fireEvent.click(screen.getByRole("button", { name: "Set up Gemini search" }));
-
-    await waitFor(() => expect(mocks.provisionGemini).toHaveBeenCalledWith({
-      jurisdictionId: "geo_1",
-      reason: "Set up legal search",
-      idempotencyKey: expect.stringMatching(/^provision-gemini-geo_1-/),
-    }));
-    expect(await screen.findByRole("status")).toHaveTextContent(/being set up/i);
+    expect(screen.queryByRole("button", { name: "Set up Gemini search" })).toBeNull();
   });
 
   it("enables a draft jurisdiction with an auditable reason", async () => {

--- a/src/components/admin/catalog-actions.tsx
+++ b/src/components/admin/catalog-actions.tsx
@@ -391,9 +391,7 @@ export function JurisdictionLifecycleActions({
     router.refresh();
   }
 
-  const canSetUp = jurisdiction.status === "draft" && (
-    jurisdiction.provider.setupState === "not_set_up" || jurisdiction.provider.setupState === "setup_failed"
-  );
+  const canRetrySetup = jurisdiction.status === "draft" && jurisdiction.provider.setupState === "setup_failed";
   const canDeleteStore = jurisdiction.status !== "enabled" && jurisdiction.provider.storeConfigured;
 
   return <div role="group" aria-label={`Lifecycle actions for ${jurisdiction.name}`} className="grid gap-2">
@@ -403,7 +401,7 @@ export function JurisdictionLifecycleActions({
     <div className="flex flex-wrap gap-2">
       {editable && jurisdiction.status !== "archived" ? <button type="button" disabled={pending} onClick={() => setEditing((current) => !current)} className={secondaryButtonClass}>Edit {jurisdiction.kind} settings</button> : null}
       {jurisdiction.status === "draft" ? <button type="button" disabled={pending} onClick={() => run("enable")} aria-label={`Enable ${jurisdiction.name}`} className={buttonClass}>Enable</button> : null}
-      {canSetUp ? <button type="button" disabled={pending} onClick={provisionGeminiStore} className={buttonClass}>{jurisdiction.provider.setupState === "setup_failed" ? "Retry setup" : "Set up Gemini search"}</button> : null}
+      {canRetrySetup ? <button type="button" disabled={pending} onClick={provisionGeminiStore} className={buttonClass}>Retry Gemini search setup</button> : null}
       {canDeleteStore ? <button type="button" disabled={pending} onClick={beginStoreDelete} className={secondaryButtonClass}>Delete Gemini store</button> : null}
       {jurisdiction.status !== "archived" ? <button type="button" disabled={pending} onClick={() => run("archive")} aria-label={`Archive ${jurisdiction.name}`} className={secondaryButtonClass}>Archive</button> : null}
     </div>


### PR DESCRIPTION
Automates Gemini File Search setup when typed geographic or organizational jurisdictions are created. Removes the normal manual setup action while retaining retry after a failed setup.\n\nValidated: 98 test files / 1,156 tests, lint, TypeScript, and diff checks.