### PR TITLE
fix(gemini): accept pending index operations

### DIFF
--- a/convex/admin/integrations/geminiFileSearch.test.ts
+++ b/convex/admin/integrations/geminiFileSearch.test.ts
@@ -53,7 +53,7 @@ describe("GeminiFileSearchAdapter", () => {
     const client = sdk();
     vi.mocked(client.fileSearchStores.uploadToFileSearchStore).mockResolvedValue({ name: OPERATION });
     vi.mocked(client.operations.get)
-      .mockResolvedValueOnce({ name: OPERATION, done: false })
+      .mockResolvedValueOnce({ name: OPERATION })
       .mockResolvedValueOnce({ name: OPERATION, done: true, response: { documentName: DOCUMENT } })
       .mockResolvedValueOnce({ name: OPERATION, done: true, error: { code: 8, message: "Quota exhausted" } });
     const adapter = new GeminiFileSearchAdapter({ apiKey: "test-key", sdk: client });
@@ -174,13 +174,22 @@ describe("GeminiFileSearchAdapter", () => {
 
   it("rejects malformed and mismatched operation poll responses", async () => {
     const client = sdk();
+    const contradictoryPendingResponse = {
+      name: OPERATION,
+      done: false,
+      response: { documentName: DOCUMENT },
+    };
     vi.mocked(client.operations.get)
-      .mockResolvedValueOnce({ name: OPERATION })
-      .mockResolvedValueOnce({ name: "operations/other", done: false });
+      .mockResolvedValueOnce({ name: "operations/other", done: false })
+      .mockResolvedValueOnce(contradictoryPendingResponse);
     const adapter = new GeminiFileSearchAdapter({ apiKey: "test-key", sdk: client });
 
     await expect(adapter.getIndexOperation(OPERATION)).rejects.toMatchObject({ kind: "invalid_response" });
-    await expect(adapter.getIndexOperation(OPERATION)).rejects.toMatchObject({ kind: "invalid_response" });
+    await expect(adapter.getIndexOperation(OPERATION)).rejects.toMatchObject({
+      kind: "invalid_response",
+      operation: "operation_poll",
+      rawResponse: JSON.stringify(contradictoryPendingResponse),
+    });
   });
 
   it.each([

--- a/convex/admin/integrations/geminiFileSearch.ts
+++ b/convex/admin/integrations/geminiFileSearch.ts
@@ -121,8 +121,20 @@ function invalidRequest(): ProviderError {
   return new ProviderError("invalid_request", false, null, "Invalid Gemini File Search request");
 }
 
-function invalidResponse(sideEffectUncertain = false): ProviderError {
-  return new ProviderError("invalid_response", false, null, "Gemini returned an invalid response", sideEffectUncertain);
+function invalidResponse(
+  sideEffectUncertain = false,
+  operation?: ProviderOperation,
+  rawResponse?: string,
+): ProviderError {
+  return new ProviderError(
+    "invalid_response",
+    false,
+    null,
+    "Gemini returned an invalid response",
+    sideEffectUncertain,
+    operation,
+    rawResponse,
+  );
 }
 
 function errorForStatus(status: number): ProviderError {
@@ -251,17 +263,22 @@ export class GeminiFileSearchAdapter {
       const operation = new UploadToFileSearchStoreOperation();
       operation.name = name;
       const response = await this.sdk.operations.get({ operation });
-      if (response.name !== name || typeof response.done !== "boolean") throw invalidResponse();
-      if (!response.done) return { done: false };
+      const done = (response as { done?: unknown }).done;
+      const malformed = () => invalidResponse(false, "operation_poll", rawProviderResponse(response));
+      if (response.name !== name || (done !== undefined && typeof done !== "boolean")) throw malformed();
+      if (done !== true) {
+        if (response.error !== undefined || response.response !== undefined) throw malformed();
+        return { done: false };
+      }
       if (response.error !== undefined) {
-        if (response.response !== undefined) throw invalidResponse();
+        if (response.response !== undefined) throw malformed();
         const parsed = completedOperationErrorSchema.safeParse(response.error);
-        if (!parsed.success) throw invalidResponse();
+        if (!parsed.success) throw malformed();
         const error = errorForRpcCode(parsed.data.code);
         return { done: true, error: { kind: error.kind, retryable: error.retryable, message: error.message } };
       }
       const documentName = documentNameSchema.safeParse(response.response?.documentName);
-      if (!documentName.success) throw invalidResponse();
+      if (!documentName.success) throw malformed();
       return { done: true, documentName: documentName.data };
     } catch (error) {
       throw translateError(error, false, "operation_poll");

--- a/convex/admin/jobs.test.ts
+++ b/convex/admin/jobs.test.ts
@@ -572,6 +572,58 @@ describe("durable Gemini jobs", () => {
     })).resolves.toEqual({ status: "manual_review", nextAttemptAt: null });
   });
 
+  it("mentions 30 minutes only after the index review window elapses", async () => {
+    vi.useFakeTimers();
+    try {
+      const startedAt = Date.UTC(2026, 8, 4, 12);
+      vi.setSystemTime(startedAt);
+      const t = createBackend();
+
+      const earlyTimeout = await seedBoundGeminiIndexJob(t, {
+        suffix: "early-poll-timeout",
+        status: "waiting_provider",
+        providerSyncState: "synced",
+      });
+      await t.run((ctx) => ctx.db.patch(earlyTimeout.jobId, { attemptCount: 3 }));
+      const earlyLease = await claimLease(t, earlyTimeout.jobId);
+      await t.mutation(recordProviderFailure, {
+        jobId: earlyTimeout.jobId,
+        leaseToken: earlyLease,
+        kind: "timeout",
+        retryable: true,
+      });
+      await expect(t.run((ctx) => ctx.db.get(earlyTimeout.versionId))).resolves.toMatchObject({
+        failureSummary: "Gemini did not confirm the index update. Search is paused until an administrator reviews the job.",
+      });
+
+      const elapsedWindow = await seedBoundGeminiIndexJob(t, {
+        suffix: "elapsed-index-window",
+        status: "waiting_provider",
+        providerSyncState: "synced",
+      });
+      await t.run(async (ctx) => {
+        const lock = await ctx.db
+          .query("documentLifecycleLocks")
+          .withIndex("by_resourceId", (q) => q.eq("resourceId", elapsedWindow.resourceId))
+          .unique();
+        if (!lock) throw new Error("expected lifecycle lock");
+        await ctx.db.patch(lock._id, { expiresAt: startedAt + 31 * 60_000 });
+      });
+      vi.setSystemTime(startedAt + 30 * 60_000);
+      const elapsedLease = await claimLease(t, elapsedWindow.jobId);
+      await t.mutation(applyGeminiProviderResult, {
+        jobId: elapsedWindow.jobId,
+        leaseToken: elapsedLease,
+        result: { kind: "index_pending" },
+      });
+      await expect(t.run((ctx) => ctx.db.get(elapsedWindow.versionId))).resolves.toMatchObject({
+        failureSummary: "Gemini did not confirm the index update within 30 minutes. Search is paused until an administrator reviews the job.",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("persists a safe Gemini diagnostic for a denied document upload", async () => {
     const t = createBackend();
     await enablePanel(t);

--- a/convex/admin/jobs.ts
+++ b/convex/admin/jobs.ts
@@ -795,7 +795,7 @@ const geminiProviderResultValidator = v.union(
 async function markGeminiJurisdictionDrifted(
   ctx: MutationCtx,
   job: Doc<"integrationJobs">,
-  errorKind: ProviderErrorKind,
+  reviewWindowElapsed: boolean,
 ) {
   if (job.type === "gemini_create_store" || job.type === "gemini_delete_store") {
     const jurisdiction = await ctx.db.get(job.targetId as Id<"jurisdictions">);
@@ -803,7 +803,7 @@ async function markGeminiJurisdictionDrifted(
     return;
   }
   const version = await ctx.db.get(job.targetId as Id<"documentVersions">);
-  const manualReviewSummary = errorKind === "timeout"
+  const manualReviewSummary = reviewWindowElapsed
     ? "Gemini did not confirm the index update within 30 minutes. Search is paused until an administrator reviews the job."
     : "Gemini did not confirm the index update. Search is paused until an administrator reviews the job.";
   if (version && job.type === "gemini_index_document") {
@@ -961,7 +961,7 @@ export const applyGeminiProviderResult = internalMutation({
           lastErrorKind: "timeout",
           updatedAt: now,
         });
-        await markGeminiJurisdictionDrifted(ctx, job, "timeout");
+        await markGeminiJurisdictionDrifted(ctx, job, true);
         await releaseGeminiExecutionPermit(ctx, job, executionJurisdiction, now);
         await auditJob(ctx, job, "failure", "integration.job_manual_review");
         return null;
@@ -1371,7 +1371,7 @@ export const recordProviderFailure = internalMutation({
       await applyPublicationJobFailure(ctx, job, now);
     }
     if (status === "manual_review") {
-      await markGeminiJurisdictionDrifted(ctx, job, args.kind);
+      await markGeminiJurisdictionDrifted(ctx, job, false);
     }
     if (status === "failed" && job.type === "gemini_create_store") {
       const jurisdiction = await ctx.db.get(job.targetId as Id<"jurisdictions">);
@@ -1457,7 +1457,7 @@ export const reconcileStaleJobs = internalMutation({
           recoveryKind,
           updatedAt: now,
         });
-        await markGeminiJurisdictionDrifted(ctx, job, "timeout");
+        await markGeminiJurisdictionDrifted(ctx, job, false);
         await releaseExpiredGeminiExecutionPermit(ctx, job, now);
         await auditJob(ctx, job, "failure", "integration.job_manual_review");
         continue;
@@ -1480,7 +1480,7 @@ export const reconcileStaleJobs = internalMutation({
           recoveryKind,
           updatedAt: now,
         });
-        await markGeminiJurisdictionDrifted(ctx, job, "timeout");
+        await markGeminiJurisdictionDrifted(ctx, job, false);
         await releaseExpiredGeminiExecutionPermit(ctx, job, now);
         await auditJob(ctx, job, "failure", "integration.job_manual_review");
         continue;

--- a/convex/admin/jobs.ts
+++ b/convex/admin/jobs.ts
@@ -792,14 +792,20 @@ const geminiProviderResultValidator = v.union(
   v.object({ kind: v.literal("store_deleted"), storeName: v.string() }),
 );
 
-async function markGeminiJurisdictionDrifted(ctx: MutationCtx, job: Doc<"integrationJobs">) {
+async function markGeminiJurisdictionDrifted(
+  ctx: MutationCtx,
+  job: Doc<"integrationJobs">,
+  errorKind: ProviderErrorKind,
+) {
   if (job.type === "gemini_create_store" || job.type === "gemini_delete_store") {
     const jurisdiction = await ctx.db.get(job.targetId as Id<"jurisdictions">);
     if (jurisdiction) await ctx.db.patch(jurisdiction._id, { providerSyncState: "drifted", updatedAt: Date.now() });
     return;
   }
   const version = await ctx.db.get(job.targetId as Id<"documentVersions">);
-  const manualReviewSummary = "Gemini did not confirm the index update within 30 minutes. Search is paused until an administrator reviews the job.";
+  const manualReviewSummary = errorKind === "timeout"
+    ? "Gemini did not confirm the index update within 30 minutes. Search is paused until an administrator reviews the job."
+    : "Gemini did not confirm the index update. Search is paused until an administrator reviews the job.";
   if (version && job.type === "gemini_index_document") {
     await ctx.db.patch(version._id, { failureSummary: manualReviewSummary, updatedAt: Date.now() });
   } else if (version && job.type === "gemini_delete_document") {
@@ -955,7 +961,7 @@ export const applyGeminiProviderResult = internalMutation({
           lastErrorKind: "timeout",
           updatedAt: now,
         });
-        await markGeminiJurisdictionDrifted(ctx, job);
+        await markGeminiJurisdictionDrifted(ctx, job, "timeout");
         await releaseGeminiExecutionPermit(ctx, job, executionJurisdiction, now);
         await auditJob(ctx, job, "failure", "integration.job_manual_review");
         return null;
@@ -1365,7 +1371,7 @@ export const recordProviderFailure = internalMutation({
       await applyPublicationJobFailure(ctx, job, now);
     }
     if (status === "manual_review") {
-      await markGeminiJurisdictionDrifted(ctx, job);
+      await markGeminiJurisdictionDrifted(ctx, job, args.kind);
     }
     if (status === "failed" && job.type === "gemini_create_store") {
       const jurisdiction = await ctx.db.get(job.targetId as Id<"jurisdictions">);
@@ -1451,7 +1457,7 @@ export const reconcileStaleJobs = internalMutation({
           recoveryKind,
           updatedAt: now,
         });
-        await markGeminiJurisdictionDrifted(ctx, job);
+        await markGeminiJurisdictionDrifted(ctx, job, "timeout");
         await releaseExpiredGeminiExecutionPermit(ctx, job, now);
         await auditJob(ctx, job, "failure", "integration.job_manual_review");
         continue;
@@ -1474,7 +1480,7 @@ export const reconcileStaleJobs = internalMutation({
           recoveryKind,
           updatedAt: now,
         });
-        await markGeminiJurisdictionDrifted(ctx, job);
+        await markGeminiJurisdictionDrifted(ctx, job, "timeout");
         await releaseExpiredGeminiExecutionPermit(ctx, job, now);
         await auditJob(ctx, job, "failure", "integration.job_manual_review");
         continue;

--- a/convex/admin/publication.test.ts
+++ b/convex/admin/publication.test.ts
@@ -346,7 +346,7 @@ describe("governed document publication", () => {
     expect(failure.status).toBe("manual_review");
     const state = await t.run(async (ctx) => ({ jurisdiction: await ctx.db.get(jurisdictionId), version: await ctx.db.get(ids[0]) }));
     expect(state.jurisdiction?.providerSyncState).toBe("drifted");
-    expect(state.version).toMatchObject({ status: "publishing", failureSummary: "Gemini did not confirm the index update within 30 minutes. Search is paused until an administrator reviews the job." });
+    expect(state.version).toMatchObject({ status: "publishing", failureSummary: "Gemini did not confirm the index update. Search is paused until an administrator reviews the job." });
   });
 
   it("rollback reindexes the immutable original, and unpublish deletes before clearing state", async () => {
@@ -1498,7 +1498,7 @@ describe("governed document publication", () => {
     const claim = await t.mutation(claimJob, { jobId: queued.jobId });
     if (!claim) throw new Error("expected delete claim");
     await t.mutation(recordProviderFailure, { jobId: queued.jobId, leaseToken: claim.leaseToken, kind: "network", retryable: true, sideEffectUncertain: true });
-    expect(await t.run(async (ctx) => ctx.db.get(ids[0]))).toMatchObject({ status: "published", failureSummary: "Gemini did not confirm the index update within 30 minutes. Search is paused until an administrator reviews the job." });
+    expect(await t.run(async (ctx) => ctx.db.get(ids[0]))).toMatchObject({ status: "published", failureSummary: "Gemini did not confirm the index update. Search is paused until an administrator reviews the job." });
     await operator.client.mutation(retryJob, { jobId: queued.jobId, reason: "Reconcile the exact document deletion", idempotencyKey: "retry-recover-unpublish" });
     const recovery = await t.run(async (ctx) => ctx.db.get(queued.jobId as Id<"integrationJobs">));
     if (!recovery?.leaseToken) throw new Error("expected recovery lease");
@@ -1584,7 +1584,7 @@ describe("governed document publication", () => {
     expect(quarantined.previous?.status).toBe("published");
     expect(quarantined.candidate).toMatchObject({
       status: "publishing",
-      failureSummary: "Gemini did not confirm the index update within 30 minutes. Search is paused until an administrator reviews the job.",
+      failureSummary: "Gemini did not confirm the index update. Search is paused until an administrator reviews the job.",
     });
     expect(quarantined.locks).toHaveLength(1);
 
@@ -1627,7 +1627,7 @@ describe("governed document publication", () => {
     const claim = await t.mutation(claimJob, { jobId: deletion._id });
     if (!claim) throw new Error("expected replacement delete claim");
     await t.mutation(recordProviderFailure, { jobId: deletion._id, leaseToken: claim.leaseToken, kind: "network", retryable: true, sideEffectUncertain: true });
-    expect(await t.run(async (ctx) => ctx.db.get(ids[1]))).toMatchObject({ status: "publishing", failureSummary: "Gemini did not confirm the index update within 30 minutes. Search is paused until an administrator reviews the job." });
+    expect(await t.run(async (ctx) => ctx.db.get(ids[1]))).toMatchObject({ status: "publishing", failureSummary: "Gemini did not confirm the index update. Search is paused until an administrator reviews the job." });
     await operator.client.mutation(retryJob, { jobId: deletion._id, reason: "Reconcile replacement deletion", idempotencyKey: "retry-recover-replacement" });
     const recovery = await t.run(async (ctx) => ctx.db.get(deletion._id as Id<"integrationJobs">));
     if (!recovery?.leaseToken) throw new Error("expected recovery lease");

--- a/src/components/admin/resource-register.test.tsx
+++ b/src/components/admin/resource-register.test.tsx
@@ -40,13 +40,13 @@ describe("legal catalog register", () => {
         versions={[
           { id: "version_1", versionNumber: 1, filename: "v1.pdf", mimeType: "application/pdf", byteSize: 10, sha256: "a".repeat(64), status: "approved", failureSummary: "Publishing failed. No version was published.", createdAt: Date.UTC(2026, 0, 1) },
           { id: "version_2", versionNumber: 2, filename: "v2.pdf", mimeType: "application/pdf", byteSize: 10, sha256: "b".repeat(64), status: "publishing", createdAt: Date.UTC(2026, 0, 2) },
-          { id: "version_3", versionNumber: 3, filename: "v3.pdf", mimeType: "application/pdf", byteSize: 10, sha256: "c".repeat(64), status: "publishing", failureSummary: "Gemini did not confirm the index update within 30 minutes. Search is paused until an administrator reviews the job.", createdAt: Date.UTC(2026, 0, 3) },
+          { id: "version_3", versionNumber: 3, filename: "v3.pdf", mimeType: "application/pdf", byteSize: 10, sha256: "c".repeat(64), status: "publishing", failureSummary: "Gemini did not confirm the index update. Search is paused until an administrator reviews the job.", createdAt: Date.UTC(2026, 0, 3) },
         ]}
       />,
     );
     expect(screen.getByText("Publishing failed. No version was published.")).toBeVisible();
     expect(screen.getByText("Gemini is indexing this document. You can leave this page; the status updates automatically.")).toBeVisible();
-    expect(screen.getByText("Gemini did not confirm the index update within 30 minutes. Search is paused until an administrator reviews the job.")).toBeVisible();
+    expect(screen.getByText("Gemini did not confirm the index update. Search is paused until an administrator reviews the job.")).toBeVisible();
     expect(screen.getByText("Indexing needs review")).toBeVisible();
   });
 });

--- a/src/components/admin/resource-register.tsx
+++ b/src/components/admin/resource-register.tsx
@@ -60,7 +60,6 @@ export type VersionHistoryItem = {
   createdAt: number;
 };
 
-const INDEX_REVIEW_MESSAGE = "Gemini did not confirm the index update within 30 minutes. Search is paused until an administrator reviews the job.";
 const INDEXING_MESSAGE = "Gemini is indexing this document. You can leave this page; the status updates automatically.";
 
 function formatBytes(bytes: number): string {
@@ -100,7 +99,7 @@ export function VersionHistory({ versions }: { versions: readonly VersionHistory
               </td>
               <td className="px-4 py-4 align-top">
                 <CatalogStatus status={version.status} />
-                {version.status === "publishing" && version.failureSummary === INDEX_REVIEW_MESSAGE ? (
+                {version.status === "publishing" && version.failureSummary ? (
                   <p className="mt-2 text-xs font-semibold uppercase tracking-[0.08em] text-[oklch(40%_0.11_45)]">Indexing needs review</p>
                 ) : null}
                 {version.failureSummary ? (


### PR DESCRIPTION
## Summary
- treat Gemini upload operations with an omitted \done\ field as pending
- keep strict validation and raw diagnostics for malformed or contradictory poll responses
- reserve the 30-minute review message for actual timeouts and remove UI copy coupling

## Verification
- 941 tests passed across 92 files
- ESLint passed
- git diff --check passed

## Build note
- Next.js production compilation passed locally
- local type-check remains blocked by the existing @convex-dev/better-auth and better-auth client type incompatibility in an untouched provider file